### PR TITLE
Palette Data

### DIFF
--- a/src/RGBlent.js
+++ b/src/RGBlent.js
@@ -13,12 +13,15 @@ export const RGBlent = (props) => {
         <Row>
           <LeftColumn>
             <LeftColumnRow className="picker__row">
-              <Picker style={{ marginTop: "15%", marginBottom: "20%" }} />
+              <Picker style={{ marginTop: "10%", marginBottom: "0%" }} />
             </LeftColumnRow>
             <LeftColumnRow className="detail__row">
               <Detail />
             </LeftColumnRow>
-            <LeftColumnRow className="palette__row">
+            <LeftColumnRow
+              style={{ marginBottom: "15%" }}
+              className="palette__row"
+            >
               <Palette />
             </LeftColumnRow>
           </LeftColumn>

--- a/src/RGBlent.js
+++ b/src/RGBlent.js
@@ -18,12 +18,8 @@ export const RGBlent = (props) => {
             <LeftColumnRow className="detail__row">
               <Detail />
             </LeftColumnRow>
-            <LeftColumnRow
-              style={{ marginBottom: "15%" }}
-              className="palette__row"
-            >
-              <Palette />
-            </LeftColumnRow>
+            {/* Palette renders it's own row */}
+            <Palette />
           </LeftColumn>
           <RightColumn>
             <MockSidebar />

--- a/src/components/ColorProvider.js
+++ b/src/components/ColorProvider.js
@@ -1,16 +1,23 @@
 import React, { createContext, useState } from "react";
+import { useQueryClient } from "react-query";
 import { authFetch, noAuthFetch } from "../utils/fetch.js";
 import { authToken } from "../utils/auth.js";
 
 export const ColorContext = createContext();
 
 export const ColorProvider = (props) => {
+  const client = useQueryClient();
   const KEYS = {
     CURRENT_COLOR: "color",
     CURRENT_COLOR_INFO: "color-info",
   };
 
-  const [color, setColor] = useState("#80ff80");
+  const [color, _setColor] = useState("#80ff80");
+
+  const setColor = (newState) => {
+    _setColor(newState);
+    client.refetchQueries(KEYS.CURRENT_COLOR_INFO);
+  };
 
   // there is one of these for each global fetch
   const getDefaultColors = () => {

--- a/src/components/ColorProvider.js
+++ b/src/components/ColorProvider.js
@@ -10,6 +10,7 @@ export const ColorProvider = (props) => {
   const KEYS = {
     CURRENT_COLOR: "color",
     CURRENT_COLOR_INFO: "color-info",
+    CURRENT_PALETTE: "palette",
   };
 
   const [color, _setColor] = useState("#80ff80");
@@ -19,7 +20,6 @@ export const ColorProvider = (props) => {
     client.refetchQueries(KEYS.CURRENT_COLOR_INFO);
   };
 
-  // there is one of these for each global fetch
   const getDefaultColors = () => {
     const path = "/default/colors";
     if (authToken()) return authFetch(path).then((res) => res.json());
@@ -37,6 +37,12 @@ export const ColorProvider = (props) => {
     return noAuthFetch(path, options).then((res) => res.json());
   };
 
+  const getPalette = (name) => {
+    const path = "/default/palette";
+    if (authToken()) return authFetch(path).then((res) => res.json());
+    return noAuthFetch(path).then((res) => res.json());
+  };
+
   return (
     <ColorContext.Provider
       value={{
@@ -45,6 +51,7 @@ export const ColorProvider = (props) => {
         KEYS,
         color,
         setColor,
+        getPalette,
       }}
     >
       {props.children}

--- a/src/components/ColorProvider.js
+++ b/src/components/ColorProvider.js
@@ -38,7 +38,8 @@ export const ColorProvider = (props) => {
   };
 
   const getPalette = (name) => {
-    const path = "/default/palette";
+    const path =
+      name === "default" ? "/default/palette" : `/palettes?name=${name}`;
     if (authToken()) return authFetch(path).then((res) => res.json());
     return noAuthFetch(path).then((res) => res.json());
   };

--- a/src/components/Detail.js
+++ b/src/components/Detail.js
@@ -49,7 +49,24 @@ export const Detail = ({ ...props }) => {
           activeAccordionName={activeAccordion}
           onChange={setActiveAccordion}
         >
-          <Accordion heading="RGB" name="RGB">
+          <Accordion
+            heading={
+              <div style={{ display: "flex", flexDirection: "row" }}>
+                <div>RGB</div>
+                {activeAccordion === "RGB" && (
+                  <div
+                    style={{
+                      textAlign: "right",
+                      margin: "auto",
+                      marginRight: 0,
+                    }}
+                    children={color}
+                  />
+                )}
+              </div>
+            }
+            name="RGB"
+          >
             <ListGroup>
               <LabelledItem
                 label="Red"

--- a/src/components/Detail.js
+++ b/src/components/Detail.js
@@ -1,10 +1,9 @@
 import React, { useState, useContext } from "react";
-import styled from "styled-components";
 import {
   Col,
   ListGroup,
   ListGroupItem,
-  AccordionGroup as ACCORDION_GROUP,
+  AccordionGroup,
   Accordion,
   H3,
 } from "@bootstrap-styled/v4";
@@ -48,6 +47,7 @@ export const Detail = ({ ...props }) => {
         <AccordionGroup
           activeAccordionName={activeAccordion}
           onChange={setActiveAccordion}
+          style={{ paddingRight: "8%" }}
         >
           <Accordion
             heading={
@@ -193,7 +193,3 @@ export const Detail = ({ ...props }) => {
     </>
   );
 };
-
-const AccordionGroup = styled(ACCORDION_GROUP)`
-  padding-right: 8%;
-`;

--- a/src/components/Detail.js
+++ b/src/components/Detail.js
@@ -37,12 +37,12 @@ export const Detail = ({ ...props }) => {
   return (
     <>
       <Col>
-        <H3 style={{ textAlign: "center", marginTop: "5%" }}>{color}</H3>
         <Swatch
           color={color}
           size={20}
           style={{ margin: "auto", marginTop: "10%" }}
         />
+        <H3 style={{ textAlign: "center", marginTop: "5%" }}>{color}</H3>
       </Col>
       <Col>
         <AccordionGroup

--- a/src/components/Detail.js
+++ b/src/components/Detail.js
@@ -5,7 +5,7 @@ import {
   ListGroupItem,
   AccordionGroup,
   Accordion,
-  H3,
+  H4,
 } from "@bootstrap-styled/v4";
 import { Swatch } from "./Swatch.js";
 import { useQuery } from "react-query";
@@ -41,7 +41,7 @@ export const Detail = ({ ...props }) => {
           size={20}
           style={{ margin: "auto", marginTop: "10%" }}
         />
-        <H3 style={{ textAlign: "center", marginTop: "5%" }}>{color}</H3>
+        <H4 style={{ textAlign: "center", marginTop: "5%" }}>{color}</H4>
       </Col>
       <Col>
         <AccordionGroup

--- a/src/components/Detail.js
+++ b/src/components/Detail.js
@@ -53,15 +53,15 @@ export const Detail = ({ ...props }) => {
             <ListGroup>
               <LabelledItem
                 label="Red"
-                data={colorInfo.isFetching || colorInfo.data.rgb.rgb_r}
+                data={colorInfo?.data && colorInfo.data.rgb.rgb_r}
               />
               <LabelledItem
                 label="Green"
-                data={colorInfo.isFetching || colorInfo.data.rgb.rgb_g}
+                data={colorInfo?.data && colorInfo.data.rgb.rgb_g}
               />
               <LabelledItem
                 label="Blue"
-                data={colorInfo.isFetching || colorInfo.data.rgb.rgb_b}
+                data={colorInfo?.data && colorInfo.data.rgb.rgb_b}
               />
             </ListGroup>
           </Accordion>
@@ -70,21 +70,21 @@ export const Detail = ({ ...props }) => {
               <LabelledItem
                 label="Hue"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.hsv.hsv_h.toFixed(2))
                 }
               />
               <LabelledItem
                 label="Saturation"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.hsv.hsv_s.toFixed(2))
                 }
               />
               <LabelledItem
                 label="Value"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.hsv.hsv_v.toFixed(2))
                 }
               />
@@ -95,21 +95,21 @@ export const Detail = ({ ...props }) => {
               <LabelledItem
                 label="Hue"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.hsl.hsl_h.toFixed(2))
                 }
               />
               <LabelledItem
                 label="Saturation"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.hsl.hsl_s.toFixed(2))
                 }
               />
               <LabelledItem
                 label="Lightness"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.hsl.hsl_l.toFixed(2))
                 }
               />
@@ -121,7 +121,7 @@ export const Detail = ({ ...props }) => {
                 label="L*"
                 separator=" =>"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.lab.lab_l.toFixed(2))
                 }
               />
@@ -129,7 +129,7 @@ export const Detail = ({ ...props }) => {
                 label="a*"
                 separator=" =>"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.lab.lab_a.toFixed(2))
                 }
               />
@@ -137,7 +137,7 @@ export const Detail = ({ ...props }) => {
                 label="b*"
                 separator=" =>"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.lab.lab_b.toFixed(2))
                 }
               />
@@ -149,7 +149,7 @@ export const Detail = ({ ...props }) => {
                 label="X"
                 separator=" =>"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.xyz.xyz_x.toFixed(2))
                 }
               />
@@ -157,7 +157,7 @@ export const Detail = ({ ...props }) => {
                 label="Y"
                 separator=" =>"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.xyz.xyz_y.toFixed(2))
                 }
               />
@@ -165,7 +165,7 @@ export const Detail = ({ ...props }) => {
                 label="Z"
                 separator=" =>"
                 data={
-                  colorInfo.isFetching ||
+                  colorInfo?.data &&
                   parseFloat(colorInfo.data.xyz.xyz_z.toFixed(2))
                 }
               />

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from "react";
+import { useQuery } from "react-query";
 import styled from "styled-components";
 import { Swatch } from "./Swatch.js";
 import {
@@ -11,7 +12,8 @@ import {
 import { ColorContext } from "./ColorProvider.js";
 
 export const Palette = (props) => {
-  const { color, setColor } = useContext(ColorContext);
+  const { color, setColor, getPalette, KEYS } = useContext(ColorContext);
+  const [name, setName] = useState("default");
   const [colors, setColors] = useState([
     "#8080ff",
     "#8080ff",
@@ -22,15 +24,55 @@ export const Palette = (props) => {
     "#8080ff",
     "#8080ff",
   ]);
-  const swatchProps = {
-    size: 8,
-    style: { margin: "8%", display: "inline-block" },
-  };
 
-  // FIXME: this is very forced styling
-  const colProps = {
-    style: { margin: "auto", paddingRight: "4%" },
-  };
+  const palette = useQuery(
+    [KEYS.CURRENT_PALETTE, name],
+    () => getPalette(name),
+    {
+      onSuccess: () =>
+        setColors(
+          palette.data.colors.map((colorObj) => colorObj.color.rgb_hex)
+        ),
+      placeholderData: {
+        // just the necessary placeholder parts
+        colors: [
+          {
+            label: "yellow-orange",
+            color: { rgb_hex: "#FFDF80" },
+          },
+          {
+            label: "yellow-green",
+            color: { rgb_hex: "#BFFF80" },
+          },
+          {
+            label: "green",
+            color: { rgb_hex: "#80FF9F" },
+          },
+          {
+            label: "cyan",
+            color: { rgb_hex: "#80FFFF" },
+          },
+          {
+            label: "blue",
+            color: { rgb_hex: "#809FFF" },
+          },
+          {
+            label: "purple",
+            color: { rgb_hex: "#BF80FF" },
+          },
+          {
+            label: "pink",
+            color: { rgb_hex: "#FF80DF" },
+          },
+          {
+            label: "red",
+            color: { rgb_hex: "#FF8080" },
+          },
+        ],
+      },
+      keepPreviousData: true,
+    }
+  );
 
   const loadFunc = (index) => () => {
     setColors(
@@ -43,18 +85,30 @@ export const Palette = (props) => {
   const Color = (props) => {
     const loadColor = () => setColor(colors[props.index]);
     return (
-      <Col {...colProps}>
+      <Col style={{ margin: "auto", paddingRight: "4%" }}>
         <Card>
-          <CardHeader>{props.label || props.color}</CardHeader>
+          <CardHeader>
+            {palette.data.colors[props.index].color.rgb_hex ===
+            colors[props.index]
+              ? palette.data.colors[props.index].label
+              : colors[props.index]}
+          </CardHeader>
           <Swatch
             {...props}
-            {...swatchProps}
+            color={colors[props.index]}
+            size={8}
+            style={{ margin: "8%", display: "inline-block" }}
             dropdownExtras={[{ children: "View Details", onClick: loadColor }]}
             onDoubleClick={loadColor}
           />
           <CardFooter>
             <FlexRow>
-              {props.label ? props.color : <Button>Save</Button>}
+              {palette.data.colors[props.index].color.rgb_hex ===
+              colors[props.index] ? (
+                colors[props.index]
+              ) : (
+                <Button>Save</Button>
+              )}
               <Button onClick={loadFunc(props.index)}>Load</Button>
             </FlexRow>
           </CardFooter>
@@ -66,7 +120,7 @@ export const Palette = (props) => {
   return (
     <>
       {colors.map((color, index) => (
-        <Color key={index} index={index} color={colors[index]} />
+        <Color key={index} index={index} />
       ))}
     </>
   );

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -1,16 +1,27 @@
-import React from "react";
+import React, { useState, useContext } from "react";
 import styled from "styled-components";
 import { Swatch } from "./Swatch.js";
 import {
   Col,
-  Row,
   Button as BUTTON,
   Card as CARD,
   CardHeader,
   CardFooter,
 } from "@bootstrap-styled/v4";
+import { ColorContext } from "./ColorProvider.js";
 
 export const Palette = (props) => {
+  const { color } = useContext(ColorContext);
+  const [colors, setColors] = useState([
+    "#8080ff",
+    "#8080ff",
+    "#8080ff",
+    "#8080ff",
+    "#8080ff",
+    "#8080ff",
+    "#8080ff",
+    "#8080ff",
+  ]);
   const swatchProps = {
     size: 8,
     style: { margin: "8%", display: "inline-block" },
@@ -21,6 +32,14 @@ export const Palette = (props) => {
     style: { margin: "auto", paddingRight: "4%" },
   };
 
+  const loadFunc = (index) => () => {
+    setColors(
+      colors.map((this_color, this_index) =>
+        index === this_index ? color : this_color
+      )
+    );
+  };
+
   const Color = (props) => {
     return (
       <Col {...colProps}>
@@ -28,7 +47,10 @@ export const Palette = (props) => {
           <CardHeader>{props.label || props.color}</CardHeader>
           <Swatch {...props} {...swatchProps} />
           <CardFooter>
-            {props.label ? props.color : <Button>Save</Button>}
+            <FlexRow>
+              {props.label ? props.color : <Button>Save</Button>}
+              <Button onClick={loadFunc(props.index)}>Load</Button>
+            </FlexRow>
           </CardFooter>
         </Card>
       </Col>
@@ -37,14 +59,9 @@ export const Palette = (props) => {
 
   return (
     <>
-      <Color color={"#8080ff"} />
-      <Color color={"#8080ff"} />
-      <Color color={"#8080ff"} />
-      <Color color={"#8080ff"} />
-      <Color color={"#8080ff"} />
-      <Color color={"#8080ff"} />
-      <Color color={"#8080ff"} />
-      <Color color={"#8080ff"} />
+      {colors.map((color, index) => (
+        <Color index={index} color={colors[index]} />
+      ))}
     </>
   );
 };
@@ -55,4 +72,11 @@ const Button = styled(BUTTON)`
 
 const Card = styled(CARD)`
   margin-bottom: 4%;
+`;
+
+const FlexRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-left: 0%;
+  margin-right: 0%;
 `;

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -51,15 +51,8 @@ export const Palette = (props) => {
     false,
   ]);
 
-  const toggleFunc = (index) => () => {
-    setTooltipStates(
-      tooltipStates.map((this_state, this_index) =>
-        index === this_index ? !this_state : this_state
-      )
-    );
-  };
-
   const Color = (props) => {
+    const loadColor = () => setColor(colors[props.index]);
     return (
       <Col {...colProps}>
         <Card>
@@ -67,7 +60,8 @@ export const Palette = (props) => {
           <Swatch
             {...props}
             {...swatchProps}
-            onDoubleClick={() => setColor(colors[props.index])}
+            dropdownExtras={[{ children: "View Details", onClick: loadColor }]}
+            onDoubleClick={loadColor}
           />
           <CardFooter>
             <FlexRow>

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -15,6 +15,7 @@ export const Palette = (props) => {
   const { color, setColor, getPalette, KEYS } = useContext(ColorContext);
   const [name, setName] = useState("default");
   const [colors, setColors] = useState([
+    // if you see these colors, the backend is not responding
     "#8080ff",
     "#8080ff",
     "#8080ff",

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -1,46 +1,58 @@
 import React from "react";
+import styled from "styled-components";
 import { Swatch } from "./Swatch.js";
-import { Col, Row } from "@bootstrap-styled/v4";
+import {
+  Col,
+  Row,
+  Button as BUTTON,
+  Card as CARD,
+  CardHeader,
+  CardFooter,
+} from "@bootstrap-styled/v4";
 
 export const Palette = (props) => {
   const swatchProps = {
     size: 8,
+    style: { margin: "8%", display: "inline-block" },
   };
 
+  // FIXME: this is very forced styling
   const colProps = {
-    style: { margin: "auto" },
+    style: { margin: "auto", paddingRight: "4%" },
+  };
+
+  const Color = (props) => {
+    return (
+      <Col {...colProps}>
+        <Card>
+          <CardHeader>{props.label || props.color}</CardHeader>
+          <Swatch {...props} {...swatchProps} />
+          <CardFooter>
+            {props.label ? props.color : <Button>Save</Button>}
+          </CardFooter>
+        </Card>
+      </Col>
+    );
   };
 
   return (
     <>
-      <Row>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-      </Row>
-      <Row style={{ marginTop: "5%", marginBottom: "15%" }}>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-        <Col {...colProps}>
-          <Swatch color={"#8080ff"} {...swatchProps} />
-        </Col>
-      </Row>
+      <Color color={"#8080ff"} />
+      <Color color={"#8080ff"} />
+      <Color color={"#8080ff"} />
+      <Color color={"#8080ff"} />
+      <Color color={"#8080ff"} />
+      <Color color={"#8080ff"} />
+      <Color color={"#8080ff"} />
+      <Color color={"#8080ff"} />
     </>
   );
 };
+
+const Button = styled(BUTTON)`
+  scale: 0.9;
+`;
+
+const Card = styled(CARD)`
+  margin-bottom: 4%;
+`;

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -10,10 +10,11 @@ import {
   Card as CARD,
   CardHeader,
   CardFooter,
+  Tooltip,
 } from "@bootstrap-styled/v4";
 import { ColorContext } from "./ColorProvider.js";
 import { DEFAULT_PALETTE_MINIMAL } from "../utils/color.js";
-import { authToken } from "../utils/auth.js";
+import { isNobody } from "../utils/auth.js";
 
 export const Palette = ({ ...props }) => {
   const { color, setColor, getPalette, KEYS } = useContext(ColorContext);
@@ -34,7 +35,7 @@ export const Palette = ({ ...props }) => {
           palette.data.colors.map((colorObj) => colorObj.color.rgb_hex)
         );
       },
-      placeholderData: DEFAULT_PALETTE_MINIMAL,
+      initialData: DEFAULT_PALETTE_MINIMAL,
       keepPreviousData: true,
       staleTime: Infinity,
     }
@@ -62,45 +63,73 @@ export const Palette = ({ ...props }) => {
     }
   };
 
+  const [openTooltip, setOpenTooltip] = useState(-1);
+  const toggleTooltipFunc = (index) => () => {
+    if (openTooltip === index) {
+      setOpenTooltip(-1);
+    } else {
+      setOpenTooltip(index);
+    }
+  };
+
   const Color = (props) => {
     const editColor = () => setColor(colors[props.index]);
-    const paletteColor = palette.data.colors[props.index];
+    const paletteColor = palette.data?.colors[props.index];
     const displayedColor = colors[props.index];
     const colorIsDirty = dirtyColor === props.index;
+    const id = "palette-color-" + props.index;
     return (
-      <Col style={{ margin: "auto", paddingRight: "4%" }}>
-        <Card
-          style={{
-            border: colorIsDirty ? "2px dotted darkgrey" : "",
-          }}
-        >
-          <CardHeader>
-            {paletteColor.color.rgb_hex === displayedColor
-              ? paletteColor.label
-              : displayedColor}
-          </CardHeader>
-          <Swatch
-            {...props}
-            color={displayedColor}
-            size={8}
-            style={{ margin: "8%", display: "inline-block" }}
-            dropdownExtras={[{ children: "View Details", onClick: editColor }]}
-            onDoubleClick={editColor}
-          />
-          <CardFooter>
-            <FlexRow>
-              <Button onClick={editFunc(props.index)}>
-                {colorIsDirty ? "Restore" : "Replace"}
-              </Button>
-              {paletteColor.color.rgb_hex === displayedColor ? (
-                <DummyButton>{displayedColor}</DummyButton>
-              ) : (
-                <Button>Save</Button>
-              )}
-            </FlexRow>
-          </CardFooter>
-        </Card>
-      </Col>
+      <>
+        <Col style={{ margin: "auto", paddingRight: "4%" }}>
+          <Card
+            style={{
+              border: colorIsDirty ? "2px dotted darkgrey" : "",
+            }}
+          >
+            <CardHeader>
+              {paletteColor.color.rgb_hex === displayedColor
+                ? paletteColor.label
+                : displayedColor}
+            </CardHeader>
+            <Swatch
+              {...props}
+              color={displayedColor}
+              size={8}
+              style={{ margin: "8%", display: "inline-block" }}
+              dropdownExtras={[
+                { children: "View Details", onClick: editColor },
+              ]}
+              onDoubleClick={editColor}
+            />
+            <CardFooter>
+              <FlexRow>
+                <Button
+                  id={id}
+                  disabled={isNobody()}
+                  onClick={editFunc(props.index)}
+                >
+                  {colorIsDirty ? "Restore" : "Replace"}
+                </Button>
+                {paletteColor.color.rgb_hex === displayedColor ? (
+                  <DummyButton>{displayedColor}</DummyButton>
+                ) : (
+                  <Button>Save</Button>
+                )}
+              </FlexRow>
+            </CardFooter>
+          </Card>
+        </Col>
+        {isNobody() && (
+          <Tooltip
+            isOpen={openTooltip === props.index}
+            toggle={toggleTooltipFunc(props.index)}
+            target={id}
+            placement="right"
+          >
+            Login/Register to edit palettes
+          </Tooltip>
+        )}
+      </>
     );
   };
 

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -10,21 +10,14 @@ import {
   CardFooter,
 } from "@bootstrap-styled/v4";
 import { ColorContext } from "./ColorProvider.js";
+import { DEFAULT_PALETTE_MINIMAL } from "../utils/color.js";
 
 export const Palette = (props) => {
   const { color, setColor, getPalette, KEYS } = useContext(ColorContext);
   const [name, setName] = useState("default");
-  const [colors, setColors] = useState([
-    // if you see these colors, the backend is not responding
-    "#8080ff",
-    "#8080ff",
-    "#8080ff",
-    "#8080ff",
-    "#8080ff",
-    "#8080ff",
-    "#8080ff",
-    "#8080ff",
-  ]);
+  const [colors, setColors] = useState(
+    DEFAULT_PALETTE_MINIMAL.colors.map((c) => c.color.rgb_hex)
+  );
 
   const palette = useQuery(
     [KEYS.CURRENT_PALETTE, name],
@@ -34,43 +27,7 @@ export const Palette = (props) => {
         setColors(
           palette.data.colors.map((colorObj) => colorObj.color.rgb_hex)
         ),
-      placeholderData: {
-        // just the necessary placeholder parts
-        colors: [
-          {
-            label: "yellow-orange",
-            color: { rgb_hex: "#FFDF80" },
-          },
-          {
-            label: "yellow-green",
-            color: { rgb_hex: "#BFFF80" },
-          },
-          {
-            label: "green",
-            color: { rgb_hex: "#80FF9F" },
-          },
-          {
-            label: "cyan",
-            color: { rgb_hex: "#80FFFF" },
-          },
-          {
-            label: "blue",
-            color: { rgb_hex: "#809FFF" },
-          },
-          {
-            label: "purple",
-            color: { rgb_hex: "#BF80FF" },
-          },
-          {
-            label: "pink",
-            color: { rgb_hex: "#FF80DF" },
-          },
-          {
-            label: "red",
-            color: { rgb_hex: "#FF8080" },
-          },
-        ],
-      },
+      placeholderData: DEFAULT_PALETTE_MINIMAL,
       keepPreviousData: true,
       staleTime: Infinity,
     }
@@ -86,18 +43,19 @@ export const Palette = (props) => {
 
   const Color = (props) => {
     const editColor = () => setColor(colors[props.index]);
+    const paletteColor = palette.data.colors[props.index];
+    const displayedColor = colors[props.index];
     return (
       <Col style={{ margin: "auto", paddingRight: "4%" }}>
         <Card>
           <CardHeader>
-            {palette.data.colors[props.index].color.rgb_hex ===
-            colors[props.index]
-              ? palette.data.colors[props.index].label
-              : colors[props.index]}
+            {paletteColor.color.rgb_hex === displayedColor
+              ? paletteColor.label
+              : displayedColor}
           </CardHeader>
           <Swatch
             {...props}
-            color={colors[props.index]}
+            color={displayedColor}
             size={8}
             style={{ margin: "8%", display: "inline-block" }}
             dropdownExtras={[{ children: "View Details", onClick: editColor }]}
@@ -106,9 +64,8 @@ export const Palette = (props) => {
           <CardFooter>
             <FlexRow>
               <Button onClick={editFunc(props.index)}>Replace</Button>
-              {palette.data.colors[props.index].color.rgb_hex ===
-              colors[props.index] ? (
-                colors[props.index]
+              {paletteColor.color.rgb_hex === displayedColor ? (
+                displayedColor
               ) : (
                 <Button>Save</Button>
               )}

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -103,13 +103,13 @@ export const Palette = (props) => {
           />
           <CardFooter>
             <FlexRow>
+              <Button onClick={loadFunc(props.index)}>Load</Button>
               {palette.data.colors[props.index].color.rgb_hex ===
               colors[props.index] ? (
                 colors[props.index]
               ) : (
                 <Button>Save</Button>
               )}
-              <Button onClick={loadFunc(props.index)}>Load</Button>
             </FlexRow>
           </CardFooter>
         </Card>

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -11,7 +11,7 @@ import {
 import { ColorContext } from "./ColorProvider.js";
 
 export const Palette = (props) => {
-  const { color } = useContext(ColorContext);
+  const { color, setColor } = useContext(ColorContext);
   const [colors, setColors] = useState([
     "#8080ff",
     "#8080ff",
@@ -40,12 +40,35 @@ export const Palette = (props) => {
     );
   };
 
+  const [tooltipStates, setTooltipStates] = useState([
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
+
+  const toggleFunc = (index) => () => {
+    setTooltipStates(
+      tooltipStates.map((this_state, this_index) =>
+        index === this_index ? !this_state : this_state
+      )
+    );
+  };
+
   const Color = (props) => {
     return (
       <Col {...colProps}>
         <Card>
           <CardHeader>{props.label || props.color}</CardHeader>
-          <Swatch {...props} {...swatchProps} />
+          <Swatch
+            {...props}
+            {...swatchProps}
+            onDoubleClick={() => setColor(colors[props.index])}
+          />
           <CardFooter>
             <FlexRow>
               {props.label ? props.color : <Button>Save</Button>}
@@ -60,7 +83,7 @@ export const Palette = (props) => {
   return (
     <>
       {colors.map((color, index) => (
-        <Color index={index} color={colors[index]} />
+        <Color key={index} index={index} color={colors[index]} />
       ))}
     </>
   );

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -40,17 +40,6 @@ export const Palette = (props) => {
     );
   };
 
-  const [tooltipStates, setTooltipStates] = useState([
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-  ]);
-
   const Color = (props) => {
     const loadColor = () => setColor(colors[props.index]);
     return (

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -71,10 +71,11 @@ export const Palette = (props) => {
         ],
       },
       keepPreviousData: true,
+      staleTime: Infinity,
     }
   );
 
-  const loadFunc = (index) => () => {
+  const editFunc = (index) => () => {
     setColors(
       colors.map((this_color, this_index) =>
         index === this_index ? color : this_color
@@ -83,7 +84,7 @@ export const Palette = (props) => {
   };
 
   const Color = (props) => {
-    const loadColor = () => setColor(colors[props.index]);
+    const editColor = () => setColor(colors[props.index]);
     return (
       <Col style={{ margin: "auto", paddingRight: "4%" }}>
         <Card>
@@ -98,12 +99,12 @@ export const Palette = (props) => {
             color={colors[props.index]}
             size={8}
             style={{ margin: "8%", display: "inline-block" }}
-            dropdownExtras={[{ children: "View Details", onClick: loadColor }]}
-            onDoubleClick={loadColor}
+            dropdownExtras={[{ children: "View Details", onClick: editColor }]}
+            onDoubleClick={editColor}
           />
           <CardFooter>
             <FlexRow>
-              <Button onClick={loadFunc(props.index)}>Load</Button>
+              <Button onClick={editFunc(props.index)}>Replace</Button>
               {palette.data.colors[props.index].color.rgb_hex ===
               colors[props.index] ? (
                 colors[props.index]

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -22,7 +22,7 @@ export const Picker = (props) => {
         />
       </Col>
       <Col>
-        <H4 style={{ textAlign: "center" }}> {pickerColor}</H4>
+        <H4> {pickerColor}</H4>
         <Row style={{ marginTop: "10%" }}>
           <Button
             onClick={() => {

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -2,15 +2,13 @@ import React, { useState, useContext } from "react";
 import styled from "styled-components";
 import "../css/HexColorPicker.css";
 import { H4, Col, Row, Button as BUTTON } from "@bootstrap-styled/v4";
-import { useQueryClient } from "react-query";
 import { HexColorPicker } from "react-colorful";
 import { ColorContext } from "./ColorProvider.js";
 
 export const Picker = (props) => {
-  const { setColor, KEYS } = useContext(ColorContext);
+  const { setColor } = useContext(ColorContext);
   const [pickerColor, setPickerColor] = useState("#80ff80");
   useContext(ColorContext);
-  const client = useQueryClient();
 
   return (
     <>
@@ -24,14 +22,7 @@ export const Picker = (props) => {
       <Col>
         <H4> {pickerColor}</H4>
         <Row style={{ marginTop: "10%" }}>
-          <Button
-            onClick={() => {
-              setColor(pickerColor);
-              client.refetchQueries(KEYS.CURRENT_COLOR_INFO, { active: true });
-            }}
-          >
-            Load This Color
-          </Button>
+          <Button onClick={() => setColor(pickerColor)}>Load This Color</Button>
           <Button onClick={() => {}}>Favorite this Color</Button>
         </Row>
       </Col>

--- a/src/components/Swatch.js
+++ b/src/components/Swatch.js
@@ -23,6 +23,10 @@ export const Swatch = (props) => {
         >
           <DropdownToggle style={{ fontSize: "1.2em" }}>☰</DropdownToggle>
           <DropdownMenu>
+            {props?.dropdownExtras &&
+              props.dropdownExtras.map((itemProps) => (
+                <DropdownItem {...itemProps} />
+              ))}
             <DropdownItem>Blend</DropdownItem>
             <DropdownItem>Favorite</DropdownItem>
           </DropdownMenu>

--- a/src/components/Swatch.js
+++ b/src/components/Swatch.js
@@ -24,8 +24,8 @@ export const Swatch = (props) => {
           <DropdownToggle style={{ fontSize: "1.2em" }}>☰</DropdownToggle>
           <DropdownMenu>
             {props?.dropdownExtras &&
-              props.dropdownExtras.map((itemProps) => (
-                <DropdownItem {...itemProps} />
+              props.dropdownExtras.map((itemProps, index) => (
+                <DropdownItem {...itemProps} key={index} />
               ))}
             <DropdownItem>Blend</DropdownItem>
             <DropdownItem>Favorite</DropdownItem>

--- a/src/css/HexColorPicker.css
+++ b/src/css/HexColorPicker.css
@@ -1,5 +1,5 @@
 .react-colorful {
   margin: auto;
   width: auto;
-  scale: 1.5;
+  /*scale: 1.5;*/
 }

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -2,3 +2,4 @@ const tokenKey = "rgblent_token";
 export const authToken = () => localStorage.getItem(tokenKey);
 export const doLogin = () => localStorage.setItem(tokenKey);
 export const doLogout = () => localStorage.removeItem(tokenKey);
+export const isNobody = () => !authToken();

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,0 +1,37 @@
+export const DEFAULT_PALETTE_MINIMAL = {
+  // just the necessary placeholder parts
+  colors: [
+    {
+      label: "yellow-orange",
+      color: { rgb_hex: "#FFDF80" },
+    },
+    {
+      label: "yellow-green",
+      color: { rgb_hex: "#BFFF80" },
+    },
+    {
+      label: "green",
+      color: { rgb_hex: "#80FF9F" },
+    },
+    {
+      label: "cyan",
+      color: { rgb_hex: "#80FFFF" },
+    },
+    {
+      label: "blue",
+      color: { rgb_hex: "#809FFF" },
+    },
+    {
+      label: "purple",
+      color: { rgb_hex: "#BF80FF" },
+    },
+    {
+      label: "pink",
+      color: { rgb_hex: "#FF80DF" },
+    },
+    {
+      label: "red",
+      color: { rgb_hex: "#FF8080" },
+    },
+  ],
+};


### PR DESCRIPTION
## CHANGES:
- `src/RGBlent.js`
	- tweaked layout styling
	- `<Palette />` now renders it's own `<Row />`
- `src/components/ColorProvider.js`
	- added `getPalette` and `CURRENT_PALETTE` query key (`KEYS`)
	- `setColor` now automatically triggers a refetch
- `src/components/Detail.js`
	- styling changes
	- when the `Accordion` section "RGB" is open, the hex code from `colorInfo` is displayed
	- the hex code for the state color to the swatch column
	- tweaked render logic
- `src/components/Picker.js`
	- styling tweaks
	- simplified load function thanks to new `setColor` in `ColorProvider`
- `src/components/Swatch.js`
	- now accepts extra dropdown menu items via props
- `src/css/HexColorPicker.css`
	- commented out scale -- I like the size but it's the wrong way to do it
- `src/utils/auth.js`
	- added `IsNobody` predicate (function that returns a `bool`)
- `src/utils/color.js`
	- added `DEFAULT_PALETTE_MINIMAL` data for query initialization
		- matches the "/default/palette" return enough to satisfy rendering
- `src/components/Palette`
	- big styling overhaul
	- state for the name of the current palette (default is "default")
	- state for each color cell (default is the minimal default palette constant)
	- implemented a query to get a palette
		- uses a compound query key that starts with a constant and ends with the palette name
		- never goes stale until manually refetched
		- onSuccess it sets the palette color state
	- palette colors are rendered as cards
		- if a user is logged in:
			- if the color slot matches it's corresponding palette slot it is "clean"
				- the slot's header will be the corresponding palette color's label
				- there is a Replace button that loads the state color into that palette slot
					- that slot is then marked as "dirty"
					- any other "dirty" slot is reverted to the palette color
			- if it is "dirty"
				- the slot's header will be the color's hex code
				- the Replace button becomes the Restore button and reverts that slot to the palette color
				- the hex code next to the Replace/Restore button becomes a Save button (currently no-op)
		- if nobody is logged in:
			- the Replace button is disabled and the card title will always be the palette color label
			- a tooltip informs the user as to why the button is disabled
	- the palette's name is displayed as a header
		- if anything is dirty, an asterisk appears next to the name

## TO TEST:
- hard to test a lot of the card slot functionality now that I added the Nobody check
- registration/login is next up so those features will be back soon

## RELATED ISSUES:

Closes #4
