### PR TITLE
Palette Swatch Grid

### DIFF
--- a/src/components/color/Palette.js
+++ b/src/components/color/Palette.js
@@ -92,7 +92,7 @@ export const Palette = ({ ...props }) => {
   return (
     // TODO: proper loader
     paletteQuery.isLoading || (
-      <>
+      <Col md={{ offset: 1 }}>
         <PaletteHeader
           paletteState={paletteState}
           setPaletteState={setPaletteState}
@@ -116,7 +116,7 @@ export const Palette = ({ ...props }) => {
             />
           ))}
         </Row>
-      </>
+      </Col>
     )
   );
 };

--- a/src/components/color/PaletteCard.js
+++ b/src/components/color/PaletteCard.js
@@ -79,9 +79,10 @@ export const PaletteCard = ({
           </FlexRow>
         </CardHeader>
         <Swatch
-          size={12}
+          size={17}
+          squish="vertical"
           style={{
-            margin: "auto",
+            margin: "1rem",
             marginTop: "0.5rem",
             marginBottom: "0.8rem",
           }}
@@ -165,7 +166,7 @@ export const PaletteCard = ({
 
 const Card = styled(CARD)`
   margin-bottom: 4%;
-  width: 16rem;
+  width: auto;
   margin-right: 0.5rem;
   margin-left: 0.5rem;
 `;

--- a/src/components/color/Swatch.js
+++ b/src/components/color/Swatch.js
@@ -48,13 +48,13 @@ export const Swatch = ({ sibling, ...props }) => {
 };
 
 const SWATCH = styled.div`
-  ${({ size }) => css`
-    height: ${size}rem;
+  ${({ size, squish }) => css`
+    height: ${size / (squish === "vertical" ? 2 : 1)}rem;
     width: ${size}rem;
   `}
   margin: auto;
   background-color: ${({ color }) => color};
-  border-radius: 100%;
+  border-radius: ${({ squish }) => (squish ? "4%" : "100%")};
   border: 1px solid darkgrey;
   box-shadow: 0px 2px 2px darkgrey;
 `;


### PR DESCRIPTION
- added the `squish` property to the Swatch which renders a rounded rectangle instead of a circle
- used the new `squish` Swatch property to render the palette in a more vertically compact fashion
